### PR TITLE
fix: support Calcit 0.12.56

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -414,14 +414,15 @@
             respo.css :refer $ defstyle
     |cirru-editor.config $ %{} :FileEntry
       :defs $ {}
-        |dev? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |dev? $ %{} :CodeEntry (:doc |) (:schema :bool)
           :code $ quote
             def dev? $ = |dev (get-env |mode)
           :examples $ []
-        |site $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |site $ %{} :CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:title "|Cirru Editor") (:icon |http://cdn.tiye.me/logo/cirru.png) (:storage-key |respo-cirru-editor)
           :examples $ []
+          :schema $ :: :map :tag :string
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns cirru-editor.config)
     |cirru-editor.core $ %{} :FileEntry
@@ -891,25 +892,36 @@
           :code $ quote
             defn cons (y xs) (prepend xs y)
           :examples $ []
-        |pos? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |pos? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn pos? (x) (&> x 0)
           :examples $ []
-        |subvec $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: :fn
+            {} (:return :bool)
+              :args $ [] :number
+        |subvec $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn subvec (xs start-index ? end-index)
               if (some? end-index) (&list:slice xs start-index end-index)
                 &list:slice xs start-index $ count xs
           :examples $ []
-        |zero? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: :fn
+            {}
+              :args $ [] (:: :list 'T) :number (:: :optional :number)
+              :generics $ [] 'T
+              :return $ :: :list 'T
+        |zero? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn zero? (x) (&= x 0)
           :examples $ []
+          :schema $ :: :fn
+            {} (:return :bool)
+              :args $ [] :number
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns cirru-editor.util)
     |cirru-editor.util.detect $ %{} :FileEntry
       :defs $ {}
-        |coord-contains? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |coord-contains? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn coord-contains? (a b)
               if (nil? a) false $ if (empty? b) true
@@ -918,22 +930,33 @@
                   recur (rest a) (rest b)
                   , false
           :examples $ []
+          :schema $ :: :fn
+            {} (:return :bool)
+              :args $ []
+                :: :optional $ :: :list :number
+                :: :list :number
         |deep? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
             defn deep? (expression)
               any? expression $ fn (item) (list? item)
           :examples $ []
-        |has-blank? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |has-blank? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn has-blank? (x) (includes? x "| ")
           :examples $ []
-        |shallow? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: :fn
+            {} (:return :bool)
+              :args $ [] :string
+        |shallow? $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn shallow? (expression)
               every?
                 fn (item) (string? item)
                 , expression
           :examples $ []
+          :schema $ :: :fn
+            {} (:return :bool)
+              :args $ [] (:: :list :string)
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns cirru-editor.util.detect)
     |cirru-editor.util.dom $ %{} :FileEntry
@@ -956,46 +979,46 @@
         :code $ quote (ns cirru-editor.util.dom)
     |cirru-editor.util.keycode $ %{} :FileEntry
       :defs $ {}
-        |backspace $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |backspace $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def backspace 8)
           :examples $ []
-        |down $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |down $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def down 40)
           :examples $ []
-        |enter $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |enter $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def enter 13)
           :examples $ []
-        |key-b $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-b $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-b 66)
           :examples $ []
-        |key-c $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-c $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-c 67)
           :examples $ []
-        |key-f $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-f $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-f 70)
           :examples $ []
-        |key-s $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-s $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-s 83)
           :examples $ []
-        |key-v $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-v $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-v 86)
           :examples $ []
-        |key-x $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |key-x $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def key-x 88)
           :examples $ []
-        |left $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |left $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def left 37)
           :examples $ []
-        |right $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |right $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def right 39)
           :examples $ []
-        |space $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |space $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def space 32)
           :examples $ []
-        |tab $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |tab $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def tab 9)
           :examples $ []
-        |up $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |up $ %{} :CodeEntry (:doc |) (:schema :number)
           :code $ quote (def up 38)
           :examples $ []
       :ns $ %{} :NsEntry (:doc |)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,8 +1,9 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |cirru-editor)
-  :configs $ {} (:init-fn |cirru-editor.main/main!) (:reload-fn |cirru-editor.main/reload!) (:version |0.6.4)
-    :modules $ [] |respo.calcit/ |lilac/ |memof/
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |cirru-editor) (:version |0.6.5)
   :entries $ {}
+    :default $ {} (:description |) (:init-fn 'cirru-editor.main/main!) (:mode :native) (:reload-fn 'cirru-editor.main/reload!)
+      :modules $ [] |respo.calcit/ |lilac/ |memof/
+      :type-slots $ {}
   :files $ {}
     |cirru-editor.comp.container $ %{} :FileEntry
       :defs $ {}
@@ -317,6 +318,14 @@
                   :keydown $ on-keydown modify! coord token on-command
                   :click $ on-click modify! coord focus
           :examples $ []
+        |create-number-pattern $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn create-number-pattern () $ new js/RegExp |-?[\d\.]+
+          :examples $ []
+          :schema $ :: :fn
+            {} (:return :dynamic)
+              :args $ []
+              :features $ #{} :js-ffi
         |on-click $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
             defn on-click (modify! coord focus)
@@ -379,7 +388,7 @@
           :examples $ []
         |pattern-number $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
-            def pattern-number $ new js/RegExp |-?[\d\.]+
+            def pattern-number $ create-number-pattern
           :examples $ []
         |style-token $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
@@ -469,7 +478,7 @@
                 _ @*store
               reset! *touched true
           :examples $ []
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               if config/dev? $ load-console-formatter!
@@ -478,6 +487,10 @@
               add-watch *store :changes $ fn (s p) (render-app!)
               println "|app started!"
           :examples $ []
+          :schema $ :: :fn
+            {} (:return :dynamic)
+              :args $ []
+              :features $ #{} :js-ffi
         |mount-target $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
@@ -634,7 +647,7 @@
                           position $ last coord
                         cond
                             = position $ dec (count parent)
-                            conj parent $ [] |
+                            conj (assert-type parent :list) ([] |)
                           :else $ concat
                             subvec parent 0 $ inc position
                             [] $ [] |
@@ -991,11 +1004,19 @@
       :defs $ {}
         |*ctx $ %{} :CodeEntry (:doc |) (:schema :dynamic)
           :code $ quote
-            defatom *ctx $ if (exists? js/document)
+            defatom *ctx $ create-context
+          :examples $ []
+        |create-context $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn create-context () $ if (exists? js/document)
               .!getContext (js/document.createElement |canvas) |2d
               , nil
           :examples $ []
-        |text-width $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: :fn
+            {} (:return :dynamic)
+              :args $ []
+              :features $ #{} :js-ffi
+        |text-width $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn text-width (content font-size font-family)
               let
@@ -1006,5 +1027,9 @@
                     .-width $ .!measureText ctx content
                   + 4 $ * (count content) 9
           :examples $ []
+          :schema $ :: :fn
+            {} (:return :number)
+              :args $ [] :string :number :string
+              :features $ #{} :js-ffi
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote (ns cirru-editor.util.measure)

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.12.14)
-  :dependencies $ {} (|Respo/respo.calcit |0.16.32)
+{} (:calcit-version |0.12.56)
+  :dependencies $ {} (|Respo/respo.calcit |0.16.59)
     |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.23
+    |calcit-lang/memof |0.0.26

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "respo-cirru-editor",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "packageManager": "yarn@4.12.0",
   "description": "Respo Cirru Editor",
   "main": "index.js",
   "scripts": {
-    "compile": "caps --ci && cr compact.cirru js",
+    "compile": "caps --ci && cr calcit.cirru js",
     "release": "yarn compile && yarn vite build --base=./"
   },
   "repository": {
@@ -19,6 +19,6 @@
     "vite": "npm:rolldown-vite@latest"
   },
   "dependencies": {
-    "@calcit/procs": "^0.12.14"
+    "@calcit/procs": "^0.12.56"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,21 +5,21 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.14":
-  version: 0.12.14
-  resolution: "@calcit/procs@npm:0.12.14"
+"@calcit/procs@npm:^0.12.56":
+  version: 0.12.56
+  resolution: "@calcit/procs@npm:0.12.56"
   dependencies:
-    "@calcit/ternary-tree": "npm:0.0.25"
+    "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
-    "@cirru/writer.ts": "npm:^0.1.7"
-  checksum: 10c0/2976708a64b2ae844f4b45a1f79de2e87f2a92f63376e26c5d7e410e06246a1eefa375046762de99686e9d38a828488c453a20e8b7c321f45183e31f29f469b1
+    "@cirru/writer.ts": "npm:^0.1.9"
+  checksum: 10c0/d0bf8d8ccd83fb9eb9e2f8e962dce535c01a2b0eb2d7ff8329d455d443a02353d2ca51b78d0763798ad43503fc96d188cfcf99f2d83d2e00e7caabe94aaeaaa4
   languageName: node
   linkType: hard
 
-"@calcit/ternary-tree@npm:0.0.25":
-  version: 0.0.25
-  resolution: "@calcit/ternary-tree@npm:0.0.25"
-  checksum: 10c0/49f01d526dec87810cc45f4e92dfa9043c07ecf64e03e2fa99c8ceca09724e8ec11308118599beffd62852f8594f8944f2c8101bc7e551ae64d421d27f91202b
+"@calcit/ternary-tree@npm:0.0.26":
+  version: 0.0.26
+  resolution: "@calcit/ternary-tree@npm:0.0.26"
+  checksum: 10c0/53fee664f72e25f3512f3a61c917fe7926e2620caab1fed68e030ee4ddf905be68b4249c2e644a4db7cadb96b23594059f73fa9c475af8a79526e8d145736563
   languageName: node
   linkType: hard
 
@@ -30,10 +30,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cirru/writer.ts@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "@cirru/writer.ts@npm:0.1.7"
-  checksum: 10c0/3548f596abef52f8d4cfe95b25fc1ded0d059869eafb403e3e340c1bcdc50fe59af9fd75f1b6d9f828129c847965f378945ed370ff9aeec9ddcc89172afad92a
+"@cirru/writer.ts@npm:^0.1.9":
+  version: 0.1.9
+  resolution: "@cirru/writer.ts@npm:0.1.9"
+  checksum: 10c0/df2672837d1bf61ee1a83b8b77ea17b9c241cb8135323567992749ee26daf3abccf43ab75d8698d67c36c8b8469f9a66c235a809a60484d71133592a9161a054
   languageName: node
   linkType: hard
 
@@ -895,7 +895,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "respo-cirru-editor@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.14"
+    "@calcit/procs": "npm:^0.12.56"
     bottom-tip: "npm:^0.1.5"
     vite: "npm:rolldown-vite@latest"
   languageName: unknown


### PR DESCRIPTION
## Summary
- upgrade Calcit and Respo dependencies to the current compatible releases
- declare JS FFI boundaries and concrete schemas for editor utilities
- reduce unresolved dynamic schema slots from 79 to 57
- compile from calcit.cirru in the release script

## Verification
- `yarn release`
- `cr js`
- `cr analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`